### PR TITLE
Fixed incorrect spelling of PerfectLib

### DIFF
--- a/guide.zh_CN/dir.md
+++ b/guide.zh_CN/dir.md
@@ -5,7 +5,7 @@ Perfect为服务器端的Swift语言环境提供了一个管理文件存储的�
 首先，请在源程序代码开始部分声明`PerfectLib`函数库：
 
 ``` swift
-import Perfectib
+import PerfectLib
 ```
 声明后您就随时可以使用`Dir`目录对象查询和操作文件系统。
 

--- a/guide.zh_CN/file.md
+++ b/guide.zh_CN/file.md
@@ -4,7 +4,7 @@ Perfect为服务器端的Swift语言环境提供了文件访问操作的便捷�
 首先，请确保`PerfectLib`已经在您的Swift源程序开始部分完成声明：
 
 ``` swift
-import Perfectib
+import PerfectLib
 ```
 声明完成之后，即可开始使用`File`文件对象来实现在文件系统中的查询和文件操作。
 

--- a/guide/dir.md
+++ b/guide/dir.md
@@ -5,7 +5,7 @@ Perfect brings file system operations into your sever-side Swift environments to
 First, ensure the `PerfectLib` is imported in your Swift file:
 
 ``` swift
-import Perfectib
+import PerfectLib
 ```
 You are now able to use the `Dir` object to query and manipulate the file system.
 

--- a/guide/file.md
+++ b/guide/file.md
@@ -4,7 +4,7 @@ Perfect brings file system operations into your sever-side Swift environment to 
 First, ensure the `PerfectLib` is imported in your Swift file:
 
 ``` swift
-import Perfectib
+import PerfectLib
 ```
 You are now able to use the `File` object to query and manipulate the file system.
 


### PR DESCRIPTION
PerfectLib was written as Perfectib (missing the 'L') in the English and Chinese versions of file.md and dir.md.