### PR TITLE
Fix the last code example in staticFileContent.md

### DIFF
--- a/guide.zh_CN/staticFileContent.md
+++ b/guide.zh_CN/staticFileContent.md
@@ -87,7 +87,7 @@ routes.add(method: .get, uri: "/files/**", handler: {
     request, response in
 
     // 获得符合通配符的请求路径
-    request.path = request.urlVariables[routeTrailingWildcardKey]
+    request.path = request.urlVariables[routeTrailingWildcardKey]!
 
     // 用文档根目录初始化静态文件句柄
     let handler = StaticFileHandler(documentRoot: "/var/www/htdocs")

--- a/guide/staticFileContent.md
+++ b/guide/staticFileContent.md
@@ -87,7 +87,7 @@ routes.add(method: .get, uri: "/files/**", handler: {
 	request, response in
 
 	// get the portion of the request path which was matched by the wildcard
-	request.path = request.urlVariables[routeTrailingWildcardKey]
+	request.path = request.urlVariables[routeTrailingWildcardKey]!
 
 	// Initialize the StaticFileHandler with a documentRoot
 	let handler = StaticFileHandler(documentRoot: "/var/www/htdocs")


### PR DESCRIPTION
Without this exclamation mark, swift 3.0 build could possibly cause
“error: value of optional type 'String?' not unwrapped;”