### PR TITLE
Fix/trad en

### DIFF
--- a/guide/gettingStarted.md
+++ b/guide/gettingStarted.md
@@ -25,7 +25,7 @@ Target: x86_64-apple-macosx10.9
 Make sure you are running the latest version of Swift 3.0. Perfect will not compile successfully if you are running a version of Swift that is lower than 3.0.
 
 ### Ubuntu Linux
-Perfect runs in Ubuntu Linux 14.04 and 15.10 environments. Perfect relies on OpenSSL, libssl-dev, and uuid-dev. To install these, in the terminal, type:
+Perfect runs in Ubuntu Linux 14.04, 15.10 and 16.04 environments. Perfect relies on OpenSSL, libssl-dev, and uuid-dev. To install these, in the terminal, type:
 
 ```
 sudo apt-get install openssl libssl-dev uuid-dev

--- a/guide/gettingStartedFromScratch.md
+++ b/guide/gettingStartedFromScratch.md
@@ -140,7 +140,7 @@ Swift Package Manager (SPM) can generate an Xcode project which can run the Perf
 swift package generate-xcodeproj
 ```
 
-Open the generated file "PerfectTemplate.xcodeproj" and add the following to the library search part for the project (not just the target):
+Open the generated file "PerfectTemplate.xcodeproj" and add the following to the "Library Search Paths" for the project (not just the target):
 
 ```
 $(PROJECT_DIR) - Recursive

--- a/guide/gettingStartedFromScratch.md
+++ b/guide/gettingStartedFromScratch.md
@@ -123,7 +123,7 @@ do {
 }
 ```
 
-Build and run the project again with:
+Build and run the project again with: 
 
 ```
 swift build


### PR DESCRIPTION
I though 2 details to fix i think in documentation in EN:
First: in Getting started we mention 2 version of Ubuntu supported and in Getting started from scratch 3. But the sentences are the same and the context as well.

Second I wanna try generation of xcode project and i cant understand what was "the library search part" for a project and i think the correction is better ;)