### PR TITLE
Update expected log output in gettingStarted.md

### DIFF
--- a/guide.zh_CN/gettingStarted.md
+++ b/guide.zh_CN/gettingStarted.md
@@ -50,7 +50,7 @@ swift build
 您应该可以在终端控制台中看到类似下面的内容：
 
 ```
-Starting HTTP server on 0.0.0.0:8181 with document root ./webroot
+[INFO] Starting HTTP server localhost on 0.0.0.0:8181
 ```
 
 服务器现在已经运行并等待连接。从浏览器打开[http://localhost:8181/](http://127.0.0.1:8181/) 可以看到欢迎信息。在终端控制台中输入组合键“control-c”可以随时终止服务器运行。

--- a/guide/gettingStarted.md
+++ b/guide/gettingStarted.md
@@ -60,7 +60,7 @@ swift build
 You should see the following output:
 
 ```
-Starting HTTP server on 0.0.0.0:8181 with document root ./webroot
+[INFO] Starting HTTP server localhost on 0.0.0.0:8181
 ```
 
 The server is now running and waiting for connections. Access [http://localhost:8181/](http://127.0.0.1:8181/) to see the greeting. Hit "control-c" to terminate the server.


### PR DESCRIPTION
This is the output I receive when I follow the instructions in `gettingStarted.md`:

    $ .build/debug/PerfectTemplate
    [INFO] Starting HTTP server localhost on 0.0.0.0:8181

It appears that [this commit](https://github.com/PerfectlySoft/Perfect-HTTPServer/commit/334b22ef79ae76780136c7bd40b421b716bee0a4#diff-45f986c6354833476c0f5b7c9a2e4cc4L185) removed the log message indicating the document root path (as is shown in the current `gettingStarted.md`), and thus this commit updates the `gettingStarted.md` with the log output that users receive when following along.

Thanks for the awesome project! ✨ 