### PR TITLE
Fix closure typo in SQLite guide

### DIFF
--- a/guide.zh_CN/SQLite.md
+++ b/guide.zh_CN/SQLite.md
@@ -123,7 +123,7 @@ do {
 
 	let demoStatement = "SELECT post_title, post_content FROM posts ORDER BY id DESC LIMIT :1"
 
-	try sqlite.forEachRow(statement: demoStatement, doBindings {
+	try sqlite.forEachRow(statement: demoStatement, doBindings: {
 		(statement: SQLiteStmt) -> () in
 
 		let bindValue = 5

--- a/guide/SQLite.md
+++ b/guide/SQLite.md
@@ -132,7 +132,7 @@ do {
 
 	let demoStatement = "SELECT post_title, post_content FROM posts ORDER BY id DESC LIMIT :1"
 
-	try sqlite.forEachRow(statement: demoStatement, doBindings {
+	try sqlite.forEachRow(statement: demoStatement, doBindings: {
 
 		(statement: SQLiteStmt) -> () in
 


### PR DESCRIPTION
- Add omitted colon for the `doBindings` parameter in the `sqlite.forEachRow` method